### PR TITLE
Add sr25519 signature scheme

### DIFF
--- a/CODING.md
+++ b/CODING.md
@@ -61,6 +61,7 @@ The `bc-ur` crate is also in this workspace and provides the UR serialization/de
 | `SymmetricKey`, `EncryptedMessage` | Types for symmetric encryption |
 | `ECPrivateKey`, `ECPublicKey` | Elliptic curve cryptography keys |
 | `Ed25519PrivateKey`, `Ed25519PublicKey` | Ed25519 cryptographic keys |
+| `Sr25519PrivateKey`, `Sr25519PublicKey` | SR25519 (Schnorr-Ristretto) cryptographic keys |
 | `X25519PrivateKey`, `X25519PublicKey` | X25519 key agreement keys |
 | `SigningPrivateKey`, `SigningPublicKey` | Keys for digital signatures |
 | `MLDSAPrivateKey`, `MLDSAPublicKey` | Post-quantum digital signature keys |
@@ -154,10 +155,11 @@ This section inventories all public API items that need documentation, ordered f
 2. **✅ `AuthenticationTag`** (`symmetric/authentication_tag.rs`) - Authentication tag for authenticated encryption
 3. **✅ `EncryptedMessage`** (`symmetric/encrypted_message.rs`) - A symmetrically-encrypted message
 
-#### Ed25519 and X25519
+#### Ed25519, SR25519, and X25519
 
 1. **✅ `Ed25519PrivateKey`**, **✅ `Ed25519PublicKey`** (`ed25519/ed25519_private_key.rs`, `ed25519/ed25519_public_key.rs`) - Ed25519 keys
-2. **✅ `X25519PrivateKey`**, **✅ `X25519PublicKey`** (`x25519/x25519_private_key.rs`, `x25519/x25519_public_key.rs`) - X25519 keys
+2. **✅ `Sr25519PrivateKey`**, **✅ `Sr25519PublicKey`** (`sr25519/sr25519_private_key.rs`, `sr25519/sr25519_public_key.rs`) - SR25519 keys
+3. **✅ `X25519PrivateKey`**, **✅ `X25519PublicKey`** (`x25519/x25519_private_key.rs`, `x25519/x25519_public_key.rs`) - X25519 keys
 
 #### ECDSA
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,8 @@ zeroize = { version = "1.8.1", default-features = false, features = [
     "zeroize_derive",
 ] }
 rand_core = "^0.9.3"
+schnorrkel = { version = "0.11.5", optional = true }
+blake2 = { version = "0.10", optional = true }
 pqcrypto-mlkem = { version = "^0.1.0", optional = true }
 pqcrypto-mldsa = { version = "^0.1.1", optional = true }
 pqcrypto-traits = { version = "^0.3.5", optional = true }
@@ -46,9 +48,10 @@ indoc = "^2.0.0"
 version-sync = "^0.9.0"
 
 [features]
-default = ["secp256k1", "ed25519", "pqcrypto", "ssh"]
+default = ["secp256k1", "ed25519", "sr25519", "pqcrypto", "ssh"]
 secp256k1 = ["bc-crypto/secp256k1"]
 ed25519 = ["bc-crypto/ed25519"]
+sr25519 = ["dep:schnorrkel", "dep:blake2"]
 pqcrypto = ["dep:pqcrypto-mlkem", "dep:pqcrypto-mldsa", "dep:pqcrypto-traits"]
 ssh = ["dep:ssh-key"]
 ssh-agent = ["dep:ssh-agent-client-rs"]

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ The library is organized into several categories of cryptographic primitives and
 | `SchnorrPublicKey`        | A Schnorr (x-only) elliptic curve public key (BIP-340)          |
 | `Ed25519PrivateKey`       | An Edwards curve (Ed25519) private key for signatures           |
 | `Ed25519PublicKey`        | An Edwards curve (Ed25519) public key                           |
+| `Sr25519PrivateKey`       | A Schnorr-Ristretto (SR25519) private key for signatures        |
+| `Sr25519PublicKey`        | A Schnorr-Ristretto (SR25519) public key                        |
 | `X25519PrivateKey`        | A Curve25519 private key used for key agreement                 |
 | `X25519PublicKey`         | A Curve25519 public key used for key agreement                  |
 
@@ -81,14 +83,14 @@ The library is organized into several categories of cryptographic primitives and
 
 ### Digital Signatures
 
-| Name                | Description                                                                   |
-| ------------------- | ----------------------------------------------------------------------------- |
-| `SigningPrivateKey` | A private key for digital signatures (Schnorr, ECDSA, Ed25519, MLDSA, or SSH) |
-| `SigningPublicKey`  | A public key for signature verification                                       |
-| `Signature`         | A digital signature supporting multiple algorithms                            |
-| `SignatureScheme`   | Enumeration of supported signature schemes                                    |
-| `Signer`            | A trait for types that can create signatures                                  |
-| `Verifier`          | A trait for types that can verify signatures                                  |
+| Name                | Description                                                                            |
+| ------------------- | -------------------------------------------------------------------------------------- |
+| `SigningPrivateKey` | A private key for digital signatures (Schnorr, ECDSA, Ed25519, Sr25519, MLDSA, or SSH) |
+| `SigningPublicKey`  | A public key for signature verification                                                |
+| `Signature`         | A digital signature supporting multiple algorithms                                     |
+| `SignatureScheme`   | Enumeration of supported signature schemes                                             |
+| `Signer`            | A trait for types that can create signatures                                           |
+| `Verifier`          | A trait for types that can verify signatures                                           |
 
 ### Key Encapsulation and Encryption
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -40,11 +40,14 @@ cargo test --lib --bins --tests --benches --no-default-features > /dev/null
 test_only_features "pqcrypto"
 test_only_features "secp256k1"
 test_only_features "ed25519"
+test_only_features "sr25519"
 test_only_features "ssh"
 
 test_only_features "ssh,ed25519"
 test_only_features "secp256k1,ed25519,pqcrypto"
 test_only_features "secp256k1,pqcrypto,ssh"
+test_only_features "sr25519,ed25519"
+test_only_features "sr25519,secp256k1"
 
 test_additional_features "ssh-agent"
 test_additional_features "ssh-agent-tests"

--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -111,6 +111,7 @@ pub fn keypair_opt(
     #[cfg(any(
         feature = "secp256k1",
         feature = "ed25519",
+        feature = "sr25519",
         feature = "ssh",
         feature = "pqcrypto"
     ))]
@@ -130,6 +131,7 @@ pub fn keypair_opt(
     #[cfg(not(any(
         feature = "secp256k1",
         feature = "ed25519",
+        feature = "sr25519",
         feature = "ssh",
         feature = "pqcrypto"
     )))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,11 @@ mod ed25519;
 #[cfg(feature = "ed25519")]
 pub use ed25519::{Ed25519PrivateKey, Ed25519PublicKey};
 
+#[cfg(feature = "sr25519")]
+mod sr25519;
+#[cfg(feature = "sr25519")]
+pub use sr25519::{Sr25519PrivateKey, Sr25519PublicKey};
+
 mod seed;
 pub use seed::Seed;
 

--- a/src/private_keys.rs
+++ b/src/private_keys.rs
@@ -156,6 +156,7 @@ impl CBORTaggedEncodable for PrivateKeys {
         #[cfg(any(
             feature = "secp256k1",
             feature = "ed25519",
+            feature = "sr25519",
             feature = "ssh",
             feature = "pqcrypto"
         ))]
@@ -169,6 +170,7 @@ impl CBORTaggedEncodable for PrivateKeys {
         #[cfg(not(any(
             feature = "secp256k1",
             feature = "ed25519",
+            feature = "sr25519",
             feature = "ssh",
             feature = "pqcrypto"
         )))]

--- a/src/public_keys.rs
+++ b/src/public_keys.rs
@@ -150,6 +150,7 @@ impl CBORTaggedEncodable for PublicKeys {
         #[cfg(any(
             feature = "secp256k1",
             feature = "ed25519",
+            feature = "sr25519",
             feature = "ssh",
             feature = "pqcrypto"
         ))]
@@ -163,6 +164,7 @@ impl CBORTaggedEncodable for PublicKeys {
         #[cfg(not(any(
             feature = "secp256k1",
             feature = "ed25519",
+            feature = "sr25519",
             feature = "ssh",
             feature = "pqcrypto"
         )))]

--- a/src/signing/mod.rs
+++ b/src/signing/mod.rs
@@ -90,7 +90,7 @@ mod tests {
     use bc_rand::make_fake_random_number_generator;
     #[cfg(any(feature = "secp256k1", feature = "pqcrypto"))]
     use dcbor::prelude::*;
-    #[cfg(any(feature = "secp256k1", feature = "ed25519"))]
+    #[cfg(any(feature = "secp256k1", feature = "ed25519", feature = "sr25519"))]
     use hex_literal::hex;
     #[cfg(feature = "secp256k1")]
     use indoc::indoc;
@@ -100,6 +100,7 @@ mod tests {
     #[cfg(any(
         feature = "secp256k1",
         feature = "ed25519",
+        feature = "sr25519",
         feature = "ssh"
     ))]
     use super::SignatureScheme;
@@ -110,17 +111,22 @@ mod tests {
     #[cfg(any(
         feature = "secp256k1",
         feature = "ed25519",
+        feature = "sr25519",
         feature = "ssh"
     ))]
     use crate::SigningOptions;
     #[cfg(all(feature = "secp256k1", not(feature = "ed25519")))]
     use crate::SigningPrivateKey;
     #[cfg(feature = "ed25519")]
-    use crate::{Ed25519PrivateKey, Signer, SigningPrivateKey, Verifier};
+    use crate::Ed25519PrivateKey;
+    #[cfg(feature = "sr25519")]
+    use crate::Sr25519PrivateKey;
+    #[cfg(any(feature = "ed25519", feature = "sr25519"))]
+    use crate::{Signer, SigningPrivateKey, Verifier};
     #[cfg(feature = "pqcrypto")]
     use crate::{MLDSA, MLDSASignature};
     #[cfg(all(
-        not(feature = "ed25519"),
+        not(any(feature = "ed25519", feature = "sr25519")),
         any(feature = "secp256k1", feature = "ssh")
     ))]
     use crate::{Signer, Verifier};
@@ -142,9 +148,17 @@ mod tests {
             "322b5c1dd5a17c3481c2297990c85c232ed3c17b52ce9905c6ec5193ad132c36"
         )));
 
+    #[cfg(feature = "sr25519")]
+    fn sr25519_signing_private_key() -> SigningPrivateKey {
+        SigningPrivateKey::new_sr25519(Sr25519PrivateKey::from_seed(hex!(
+            "322b5c1dd5a17c3481c2297990c85c232ed3c17b52ce9905c6ec5193ad132c36"
+        )))
+    }
+
     #[cfg(any(
         feature = "secp256k1",
         feature = "ed25519",
+        feature = "sr25519",
         feature = "pqcrypto",
         feature = "ssh"
     ))]
@@ -243,6 +257,22 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "sr25519")]
+    fn test_sr25519_signing() {
+        let private_key = sr25519_signing_private_key();
+        let public_key = private_key.public_key().unwrap();
+        let signature = private_key.sign(MESSAGE).unwrap();
+
+        assert!(public_key.verify(&signature, MESSAGE));
+        assert!(!public_key.verify(&signature, b"Wolf Mcnally"));
+
+        // SR25519 signatures include randomness, so they differ each time
+        let another_signature = private_key.sign(MESSAGE).unwrap();
+        assert_ne!(signature, another_signature);
+        assert!(public_key.verify(&another_signature, MESSAGE));
+    }
+
+    #[test]
     #[cfg(feature = "pqcrypto")]
     fn test_mldsa_signing() {
         let (private_key, public_key) = MLDSA::MLDSA65.keypair();
@@ -268,7 +298,7 @@ mod tests {
         assert_eq!(signature, received_signature);
     }
 
-    #[cfg(any(feature = "secp256k1", feature = "ed25519", feature = "ssh"))]
+    #[cfg(any(feature = "secp256k1", feature = "ed25519", feature = "sr25519", feature = "ssh"))]
     fn test_keypair_signing(
         scheme: SignatureScheme,
         options: Option<SigningOptions>,
@@ -298,9 +328,15 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "sr25519")]
+    fn test_sr25519_keypair() {
+        test_keypair_signing(SignatureScheme::Sr25519, None);
+    }
+
+    #[test]
     #[cfg(all(
         feature = "pqcrypto",
-        any(feature = "secp256k1", feature = "ed25519")
+        any(feature = "secp256k1", feature = "ed25519", feature = "sr25519")
     ))]
     fn test_mldsa44_keypair() {
         test_keypair_signing(SignatureScheme::MLDSA44, None);
@@ -309,7 +345,7 @@ mod tests {
     #[test]
     #[cfg(all(
         feature = "pqcrypto",
-        any(feature = "secp256k1", feature = "ed25519")
+        any(feature = "secp256k1", feature = "ed25519", feature = "sr25519")
     ))]
     fn test_mldsa65_keypair() {
         test_keypair_signing(SignatureScheme::MLDSA65, None);
@@ -318,7 +354,7 @@ mod tests {
     #[test]
     #[cfg(all(
         feature = "pqcrypto",
-        any(feature = "secp256k1", feature = "ed25519")
+        any(feature = "secp256k1", feature = "ed25519", feature = "sr25519")
     ))]
     fn test_mldsa87_keypair() {
         test_keypair_signing(SignatureScheme::MLDSA87, None);

--- a/src/signing/mod.rs
+++ b/src/signing/mod.rs
@@ -242,6 +242,22 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "sr25519")]
+    fn test_sr25519_cbor() {
+        let private_key = sr25519_signing_private_key();
+        let signature = private_key.sign(MESSAGE).unwrap();
+        let signature_cbor: CBOR = signature.clone().into();
+        let tagged_cbor_data = signature_cbor.to_cbor_data();
+
+        let received_signature =
+            Signature::from_tagged_cbor_data(&tagged_cbor_data).unwrap();
+
+        let public_key = private_key.public_key().unwrap();
+        assert!(public_key.verify(&signature, MESSAGE));
+        assert!(public_key.verify(&received_signature, MESSAGE));
+    }
+
+    #[test]
     #[cfg(feature = "ed25519")]
     fn test_ed25519_signing() {
         let public_key = ED25519_SIGNING_PRIVATE_KEY.public_key().unwrap();

--- a/src/signing/signature.rs
+++ b/src/signing/signature.rs
@@ -620,6 +620,8 @@ impl CBORTaggedEncodable for Signature {
     ///   signature
     /// - SSH: A tagged text string containing the PEM-encoded signature
     /// - ML-DSA: Delegates to the MLDSASignature implementation
+    /// - Sr25519: An array containing the discriminator 3 and the 64-byte
+    ///   signature
     #[allow(unreachable_patterns)]
     fn untagged_cbor(&self) -> CBOR {
         match self {

--- a/src/signing/signature.rs
+++ b/src/signing/signature.rs
@@ -707,7 +707,7 @@ impl CBORTaggedDecodable for Signature {
                     let mut drain = elements.drain(0..);
                     let ele_0 = drain.next().unwrap().into_case();
                     #[cfg_attr(
-                        not(any(feature = "secp256k1", feature = "ed25519")),
+                        not(any(feature = "secp256k1", feature = "ed25519", feature = "sr25519")),
                         allow(unused_variables)
                     )]
                     let ele_1 = drain.next().unwrap().into_case();
@@ -726,6 +726,12 @@ impl CBORTaggedDecodable for Signature {
                         CBORCase::Unsigned(2) => {
                             if let CBORCase::ByteString(data) = ele_1 {
                                 return Ok(Self::ed25519_from_data_ref(data)?);
+                            }
+                        }
+                        #[cfg(feature = "sr25519")]
+                        CBORCase::Unsigned(3) => {
+                            if let CBORCase::ByteString(data) = ele_1 {
+                                return Ok(Self::sr25519_from_data_ref(data)?);
                             }
                         }
                         _ => (),

--- a/src/signing/signature_scheme.rs
+++ b/src/signing/signature_scheme.rs
@@ -7,6 +7,8 @@ use super::{SigningPrivateKey, SigningPublicKey};
 use crate::ECPrivateKey;
 #[cfg(feature = "ed25519")]
 use crate::Ed25519PrivateKey;
+#[cfg(feature = "sr25519")]
+use crate::Sr25519PrivateKey;
 #[cfg(feature = "ssh")]
 use crate::PrivateKeyBase;
 #[cfg_attr(not(feature = "pqcrypto"), allow(unused_imports))]
@@ -53,6 +55,10 @@ pub enum SignatureScheme {
     #[cfg(feature = "ed25519")]
     #[cfg_attr(all(feature = "ed25519", not(feature = "secp256k1")), default)]
     Ed25519,
+
+    /// SR25519 (Schnorr-Ristretto) signature scheme
+    #[cfg(feature = "sr25519")]
+    Sr25519,
 
     /// ML-DSA44 post-quantum signature scheme (NIST level 2)
     #[cfg(feature = "pqcrypto")]
@@ -169,6 +175,13 @@ impl SignatureScheme {
             Self::Ed25519 => {
                 let private_key =
                     SigningPrivateKey::new_ed25519(Ed25519PrivateKey::new());
+                let public_key = private_key.public_key().unwrap();
+                (private_key, public_key)
+            }
+            #[cfg(feature = "sr25519")]
+            Self::Sr25519 => {
+                let private_key =
+                    SigningPrivateKey::new_sr25519(Sr25519PrivateKey::new());
                 let public_key = private_key.public_key().unwrap();
                 (private_key, public_key)
             }
@@ -328,6 +341,14 @@ impl SignatureScheme {
             Self::Ed25519 => {
                 let private_key = SigningPrivateKey::new_ed25519(
                     Ed25519PrivateKey::new_using(_rng),
+                );
+                let public_key = private_key.public_key().unwrap();
+                Ok((private_key, public_key))
+            }
+            #[cfg(feature = "sr25519")]
+            Self::Sr25519 => {
+                let private_key = SigningPrivateKey::new_sr25519(
+                    Sr25519PrivateKey::new_using(_rng),
                 );
                 let public_key = private_key.public_key().unwrap();
                 Ok((private_key, public_key))

--- a/src/signing/signing_public_key.rs
+++ b/src/signing/signing_public_key.rs
@@ -418,6 +418,8 @@ impl CBORTaggedEncodable for SigningPublicKey {
     ///   public key
     /// - SSH: A tagged text string containing the OpenSSH-encoded public key
     /// - ML-DSA: Delegates to the MLDSAPublicKey implementation
+    /// - Sr25519: An array containing the discriminator 3 and the 32-byte
+    ///   public key
     #[allow(unreachable_patterns)]
     fn untagged_cbor(&self) -> CBOR {
         match self {

--- a/src/sr25519/mod.rs
+++ b/src/sr25519/mod.rs
@@ -10,7 +10,7 @@
 //! over the Ristretto group. It provides:
 //!
 //! - High security and performance
-//! - Deterministic signatures
+//! - Non-deterministic signatures
 //! - Compatibility with Substrate and Polkadot ecosystems
 //! - Support for hierarchical deterministic key derivation (HDKD)
 //!

--- a/src/sr25519/mod.rs
+++ b/src/sr25519/mod.rs
@@ -1,0 +1,24 @@
+//! SR25519 digital signature algorithm types.
+//!
+//! This module provides types for working with the SR25519 digital signature
+//! algorithm:
+//!
+//! - `Sr25519PrivateKey`: A 32-byte private key for signing data
+//! - `Sr25519PublicKey`: A 32-byte public key for verifying signatures
+//!
+//! SR25519 (Schnorr-Ristretto) is a signature scheme based on Schnorr signatures
+//! over the Ristretto group. It provides:
+//!
+//! - High security and performance
+//! - Deterministic signatures
+//! - Compatibility with Substrate and Polkadot ecosystems
+//! - Support for hierarchical deterministic key derivation (HDKD)
+//!
+//! Unlike Ed25519, SR25519 uses Schnorr signatures which enable more advanced
+//! cryptographic protocols and better batching capabilities.
+
+mod sr25519_private_key;
+pub use sr25519_private_key::Sr25519PrivateKey;
+
+mod sr25519_public_key;
+pub use sr25519_public_key::{Sr25519PublicKey, SR25519_SIGNATURE_SIZE};

--- a/src/sr25519/sr25519_private_key.rs
+++ b/src/sr25519/sr25519_private_key.rs
@@ -1,0 +1,182 @@
+use bc_rand::{RandomNumberGenerator, SecureRandomNumberGenerator};
+use schnorrkel::{
+    Keypair, MiniSecretKey, SecretKey, Signature as SchnorrkelSignature,
+    signing_context,
+};
+
+use crate::{
+    Digest, Error, Reference, ReferenceProvider, Result, Sr25519PublicKey,
+};
+
+pub const SR25519_PRIVATE_KEY_SIZE: usize = 32;
+pub const SR25519_SIGNATURE_SIZE: usize = 64;
+
+/// An SR25519 private key for creating digital signatures.
+///
+/// SR25519 is a Schnorr signature scheme based on the Ristretto group, providing:
+///
+/// - Fast signature creation and verification
+/// - Batch verification capabilities
+/// - Hierarchical deterministic key derivation
+/// - High security level (equivalent to 128 bits of symmetric security)
+/// - Compatibility with Substrate and Polkadot ecosystems
+///
+/// This implementation allows:
+/// - Creating random SR25519 private keys
+/// - Deriving the corresponding public key
+/// - Signing messages with context support
+/// - Converting between various formats
+#[derive(Clone, PartialEq, Eq)]
+pub struct Sr25519PrivateKey {
+    secret: SecretKey,
+}
+
+impl Sr25519PrivateKey {
+    /// Creates a new random SR25519 private key.
+    pub fn new() -> Self {
+        let mut rng = SecureRandomNumberGenerator;
+        Self::new_using(&mut rng)
+    }
+
+    /// Creates a new random SR25519 private key using the given random number
+    /// generator.
+    pub fn new_using(rng: &mut impl RandomNumberGenerator) -> Self {
+        let mut seed = [0u8; SR25519_PRIVATE_KEY_SIZE];
+        rng.fill_random_data(&mut seed);
+        Self::from_seed(seed)
+    }
+
+    /// Creates an SR25519 private key from a 32-byte seed.
+    pub fn from_seed(seed: [u8; SR25519_PRIVATE_KEY_SIZE]) -> Self {
+        let mini_secret = MiniSecretKey::from_bytes(&seed)
+            .expect("32 bytes always valid for MiniSecretKey");
+        let secret = mini_secret.expand(schnorrkel::ExpansionMode::Ed25519);
+        Self { secret }
+    }
+
+    /// Restores an SR25519 private key from a seed reference.
+    pub fn from_seed_ref(data: impl AsRef<[u8]>) -> Result<Self> {
+        let data = data.as_ref();
+        if data.len() != SR25519_PRIVATE_KEY_SIZE {
+            return Err(Error::invalid_size(
+                "SR25519 private key seed",
+                SR25519_PRIVATE_KEY_SIZE,
+                data.len(),
+            ));
+        }
+        let mut seed = [0u8; SR25519_PRIVATE_KEY_SIZE];
+        seed.copy_from_slice(data);
+        Ok(Self::from_seed(seed))
+    }
+
+    /// Derives a new SR25519 private key from the given key material.
+    pub fn derive_from_key_material(key_material: impl AsRef<[u8]>) -> Self {
+        let mut seed = [0u8; SR25519_PRIVATE_KEY_SIZE];
+        let material = key_material.as_ref();
+
+        // Use BLAKE2b to derive a seed from arbitrary length key material
+        use blake2::{Blake2b512, Digest as Blake2Digest};
+        let mut hasher = Blake2b512::new();
+        hasher.update(material);
+        let result = hasher.finalize();
+        seed.copy_from_slice(&result[..32]);
+
+        Self::from_seed(seed)
+    }
+
+    /// Returns the seed bytes of this private key.
+    pub fn to_seed(&self) -> [u8; SR25519_PRIVATE_KEY_SIZE] {
+        self.secret.to_bytes()[..SR25519_PRIVATE_KEY_SIZE]
+            .try_into()
+            .expect("secret key is 32 bytes")
+    }
+
+    /// Get the SR25519 private key seed as bytes.
+    pub fn as_bytes(&self) -> Vec<u8> {
+        self.to_seed().to_vec()
+    }
+
+    /// Returns the private key seed as a hex string.
+    pub fn hex(&self) -> String {
+        hex::encode(self.to_seed())
+    }
+
+    /// Creates an SR25519 private key from a hex string.
+    pub fn from_hex(hex_str: impl AsRef<str>) -> Result<Self> {
+        let data = hex::decode(hex_str.as_ref())?;
+        Self::from_seed_ref(data)
+    }
+
+    /// Derives the public key from this SR25519 private key.
+    pub fn public_key(&self) -> Sr25519PublicKey {
+        let keypair = Keypair {
+            secret: self.secret.clone(),
+            public: self.secret.to_public(),
+        };
+        Sr25519PublicKey::from_public_key(keypair.public)
+    }
+
+    /// Signs a message with this SR25519 private key.
+    ///
+    /// # Arguments
+    ///
+    /// * `message` - The message to sign
+    /// * `context` - Optional signing context (defaults to "substrate" if None)
+    pub fn sign(&self, message: impl AsRef<[u8]>) -> [u8; SR25519_SIGNATURE_SIZE] {
+        self.sign_with_context(message, b"substrate")
+    }
+
+    /// Signs a message with a specific context.
+    pub fn sign_with_context(
+        &self,
+        message: impl AsRef<[u8]>,
+        context: &[u8],
+    ) -> [u8; SR25519_SIGNATURE_SIZE] {
+        let keypair = Keypair {
+            secret: self.secret.clone(),
+            public: self.secret.to_public(),
+        };
+        let ctx = signing_context(context);
+        let signature: SchnorrkelSignature = keypair.sign(ctx.bytes(message.as_ref()));
+        signature.to_bytes()
+    }
+}
+
+impl From<[u8; SR25519_PRIVATE_KEY_SIZE]> for Sr25519PrivateKey {
+    fn from(seed: [u8; SR25519_PRIVATE_KEY_SIZE]) -> Self {
+        Self::from_seed(seed)
+    }
+}
+
+// Note: AsRef<[u8]> is not implemented because we cannot return a reference
+// to temporary data. Use to_seed() instead.
+
+impl std::fmt::Debug for Sr25519PrivateKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Sr25519PrivateKey({})", self.hex())
+    }
+}
+
+impl Default for Sr25519PrivateKey {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ReferenceProvider for Sr25519PrivateKey {
+    fn reference(&self) -> Reference {
+        Reference::from_digest(Digest::from_image(self.to_seed()))
+    }
+}
+
+impl std::fmt::Display for Sr25519PrivateKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Sr25519PrivateKey")
+    }
+}
+
+impl std::hash::Hash for Sr25519PrivateKey {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.to_seed().hash(state);
+    }
+}

--- a/src/sr25519/sr25519_public_key.rs
+++ b/src/sr25519/sr25519_public_key.rs
@@ -1,0 +1,144 @@
+use schnorrkel::{
+    PublicKey, Signature as SchnorrkelSignature, signing_context,
+};
+
+use crate::{Digest, Error, Reference, ReferenceProvider, Result};
+
+pub const SR25519_PUBLIC_KEY_SIZE: usize = 32;
+pub const SR25519_SIGNATURE_SIZE: usize = 64;
+
+/// An SR25519 public key for verifying digital signatures.
+///
+/// SR25519 public keys are used to verify signatures created with the
+/// corresponding private key. The SR25519 signature system provides:
+///
+/// - Fast signature verification
+/// - Batch verification capabilities
+/// - Small public keys (32 bytes)
+/// - High security with resistance to various attacks
+/// - Compatibility with Substrate and Polkadot ecosystems
+///
+/// This implementation allows:
+/// - Creating SR25519 public keys from raw data
+/// - Verifying signatures against messages
+/// - Converting between various formats
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Sr25519PublicKey([u8; SR25519_PUBLIC_KEY_SIZE]);
+
+impl Sr25519PublicKey {
+    /// Restores an SR25519 public key from an array of bytes.
+    pub const fn from_data(data: [u8; SR25519_PUBLIC_KEY_SIZE]) -> Self {
+        Self(data)
+    }
+
+    /// Restores an SR25519 public key from a byte reference.
+    pub fn from_data_ref(data: impl AsRef<[u8]>) -> Result<Self> {
+        let data = data.as_ref();
+        if data.len() != SR25519_PUBLIC_KEY_SIZE {
+            return Err(Error::invalid_size(
+                "SR25519 public key",
+                SR25519_PUBLIC_KEY_SIZE,
+                data.len(),
+            ));
+        }
+        let mut key = [0u8; SR25519_PUBLIC_KEY_SIZE];
+        key.copy_from_slice(data);
+        Ok(Self(key))
+    }
+
+    /// Creates an SR25519PublicKey from a schnorrkel PublicKey.
+    pub(crate) fn from_public_key(public: PublicKey) -> Self {
+        Self(public.to_bytes())
+    }
+
+    /// Returns the SR25519 public key as an array of bytes.
+    pub fn data(&self) -> &[u8; SR25519_PUBLIC_KEY_SIZE] {
+        &self.0
+    }
+
+    /// Get the SR25519 public key as a byte slice.
+    pub fn as_bytes(&self) -> &[u8] {
+        self.as_ref()
+    }
+
+    /// Returns the public key as a hex string.
+    fn hex(&self) -> String {
+        hex::encode(self.data())
+    }
+
+    /// Creates an SR25519 public key from a hex string.
+    pub fn from_hex(hex_str: impl AsRef<str>) -> Result<Self> {
+        let data = hex::decode(hex_str.as_ref())?;
+        Self::from_data_ref(data)
+    }
+
+    /// Converts this public key to a schnorrkel PublicKey.
+    fn to_schnorrkel_public(self) -> Result<PublicKey> {
+        PublicKey::from_bytes(&self.0).map_err(|e| {
+            Error::general(format!("Invalid SR25519 public key: {}", e))
+        })
+    }
+
+    /// Verifies the given SR25519 signature for the given message using this
+    /// SR25519 public key with the default "substrate" context.
+    pub fn verify(
+        &self,
+        signature: &[u8; SR25519_SIGNATURE_SIZE],
+        message: impl AsRef<[u8]>,
+    ) -> bool {
+        self.verify_with_context(signature, message, b"substrate")
+    }
+
+    /// Verifies a signature with a specific context.
+    pub fn verify_with_context(
+        &self,
+        signature: &[u8; SR25519_SIGNATURE_SIZE],
+        message: impl AsRef<[u8]>,
+        context: &[u8],
+    ) -> bool {
+        let public_key = match self.to_schnorrkel_public() {
+            Ok(pk) => pk,
+            Err(_) => return false,
+        };
+
+        let sig = match SchnorrkelSignature::from_bytes(signature) {
+            Ok(s) => s,
+            Err(_) => return false,
+        };
+
+        let ctx = signing_context(context);
+        public_key
+            .verify(ctx.bytes(message.as_ref()), &sig)
+            .is_ok()
+    }
+}
+
+impl AsRef<[u8]> for Sr25519PublicKey {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for Sr25519PublicKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Sr25519PublicKey({})", self.hex())
+    }
+}
+
+impl From<[u8; SR25519_PUBLIC_KEY_SIZE]> for Sr25519PublicKey {
+    fn from(value: [u8; SR25519_PUBLIC_KEY_SIZE]) -> Self {
+        Self::from_data(value)
+    }
+}
+
+impl ReferenceProvider for Sr25519PublicKey {
+    fn reference(&self) -> Reference {
+        Reference::from_digest(Digest::from_image(self.data()))
+    }
+}
+
+impl std::fmt::Display for Sr25519PublicKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Sr25519PublicKey({})", self.ref_hex_short())
+    }
+}


### PR DESCRIPTION
Hello @wolfmcnally ,
This PR aims to add sr25119 support. This is the default signature type used by Polkadot and any Substrate-compatible blockchain. More info [here](https://wiki.polkadot.com/learn/learn-cryptography/)